### PR TITLE
Provide CLI for all Nomadize commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,15 @@ After a config file is in place  add `require 'nomadize/tasks'` to your rake fil
 * `rake db:rollback[count]` - rollback migrations (default count: 1)
 * `rake db:generate_template_config` - generate a config file in `config/database.yml`
 
+Alternatively you can use the commandline tool `nomadize`:
+
+* `nomadize create` - creates a database and a schema_migrations table
+* `nomadize drop`   - dumps your poor poor database
+* `nomadize new_migration $migration_name` - creates a timestamped migration file in db/migrations/ just fill in the details.
+* `nomadize migrate` - runs migrations found in db/migrations that have not been run yet
+* `nomadize status` - see which migrations have or have not been run
+* `nomadize rollback $count` - rollback migrations (default count: 1)
+
 Migrations are written in SQL in the generated YAML files:
 
 ```

--- a/exe/nomadize
+++ b/exe/nomadize
@@ -1,6 +1,14 @@
 #!/usr/bin/env ruby
 
 require 'nomadize'
+require 'nomadize/help'
+
+def show_help
+  puts "Usage:"
+  Nomadize.help.each_pair do |command, help|
+    puts "  nomadize #{command.to_s.ljust(15)} #{help}"
+  end
+end
 
 def migration_name
   ARGV.fetch(1)
@@ -9,6 +17,8 @@ rescue IndexError
 end
 
 case ARGV[0]
+when '-h' then show_help
+when '--help' then show_help
 when 'create' then Nomadize.create_database
 when 'drop' then Nomadize.drop_database
 when 'new_migration' then Nomadize.generate_template_migration_file(migration_name)

--- a/exe/nomadize
+++ b/exe/nomadize
@@ -1,0 +1,20 @@
+#!/usr/bin/env ruby
+
+require 'nomadize'
+
+def migration_name
+  ARGV.fetch(1)
+rescue IndexError
+  abort 'Error: Migration name not provided'
+end
+
+case ARGV[0]
+when 'create' then Nomadize.create_database
+when 'drop' then Nomadize.drop_database
+when 'new_migration' then Nomadize.generate_template_migration_file(migration_name)
+when 'migrate' then Nomadize.migrate
+when 'status' then Nomadize.status
+when 'rollback' then Nomadize.rollback(ARGV.fetch(1, 1))
+when nil then abort 'Error: No Command Provided'
+else abort "Error: Unknown Command '#{ARGV[0]}'"
+end

--- a/lib/nomadize/help.rb
+++ b/lib/nomadize/help.rb
@@ -1,0 +1,11 @@
+module Nomadize
+  @help = {
+    create: 'Create database using name in {appdir}/config/database.yml',
+    drop: 'Drop database using name in {appdir}/config/database.yml',
+    new_migration: 'Generate a migration template file. default directory: {appdir}/db/migrations',
+    migrate: 'Run migrations',
+    status: 'View the status of known migrations',
+    rollback: 'Rollback migrations (default count: 1)'
+  }
+  class << self; attr_reader :help; end
+end

--- a/lib/nomadize/tasks.rb
+++ b/lib/nomadize/tasks.rb
@@ -1,33 +1,34 @@
 require 'nomadize'
+require 'nomadize/help'
 
 namespace :db do
 
-  desc 'Create database using name in {appdir}/config/database.yml'
+  desc Nomadize.help.fetch(:create)
   task :create do
     Nomadize.create_database
   end
 
-  desc 'drop database using name in {appdir}/config/database.yml'
+  desc Nomadize.help.fetch(:drop)
   task :drop do
     Nomadize.drop_database
   end
 
-  desc "Generate a migration template file. default directory: {appdir}/db/migrations"
+  desc Nomadize.help.fetch(:new_migration)
   task :new_migration, [:migration_name] do |_, args|
     Nomadize.generate_template_migration_file(args.migration_name)
   end
 
-  desc 'Run migrations'
+  desc Nomadize.help.fetch(:migrate)
   task :migrate do
     Nomadize.run_migrations
   end
 
-  desc 'view the status of known migrations'
+  desc Nomadize.help.fetch(:status)
   task :status do
     Nomadize.status
   end
 
-  desc 'rollback migrations (default count: 1)'
+  desc Nomadize.help.fetch(:rollback)
   task :rollback, :steps do |_, args|
     count = args.steps || 1
     Nomadize.rollback(count)


### PR DESCRIPTION
An alternative way to call the Nomadize commands for people that want to call it directly or for example via make.

Not everyone uses Rake as their task runner, some people use Make instead. This executable makes it possible to use Nomadize via Make. It also allows it to just run it via the commandline of course :smile: 
